### PR TITLE
Integration of MongoDB for feedbacks

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,5 +14,6 @@ RUN pip install --upgrade pip && \
 COPY streamlit_app.py .
 COPY ./utils ./utils
 COPY ./assets ./assets
+COPY ../common ./common
 
 CMD ["streamlit", "run", "streamlit_app.py"]

--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -9,3 +9,4 @@ google-auth-oauthlib==1.2.0
 gspread==6.1.2
 python-dotenv==1.0.1
 flask==3.0.3
+pymongo==4.6.3

--- a/frontend/utils/feedback.py
+++ b/frontend/utils/feedback.py
@@ -5,6 +5,9 @@ from datetime import datetime, timezone
 from dotenv import load_dotenv
 import os
 from typing import Optional, Any
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))) 
+from common.mongoClient import submit_feedback
 
 load_dotenv()
 
@@ -55,6 +58,43 @@ def format_context(context: list[str]) -> str:
     """
     assert isinstance(context, list), "Context should be a list of strings."
     return "\n".join(context)
+
+
+def submit_feedback_to_mongoDB(
+    question: str,
+    answer: str,
+    sources: list[str],
+    context: list[str],
+    issue: str,
+    version: str,
+) -> None:
+    """
+    Submit feedback to a specific MongoDB database.
+
+    Args:
+    - question (str): The question for which feedback is being submitted.
+    - answer (str): The generated answer to the question.
+    - sources (list[str]): Source data used for the answer.
+    - context (list[str]): Additional context from the RAG.
+    - issue (str): Details about the issue.
+    - version (str): Version information.
+
+    Returns:
+    - None
+    """
+    try:
+        result = submit_feedback(
+            question=question,
+            answer=answer,
+            sources=sources,
+            context=context,
+            issue=issue,
+            version=version,
+        )
+        if not result:
+            st.sidebar.error("Failed to submit feedback to MongoDB")
+    except Exception as e:
+        st.sidebar.error(f"Error submitting feedback to MongoDB: {e}")
 
 
 def submit_feedback_to_google_sheet(
@@ -184,6 +224,14 @@ def show_feedback_form(
             gen_ans = interactions[selected_index + 1]["content"]
 
             submit_feedback_to_google_sheet(
+                question=selected_question,
+                answer=gen_ans,
+                sources=sources,  # Now passing as list
+                context=context,  # Now passing as list
+                issue=feedback,
+                version=os.getenv("RAG_VERSION", get_git_commit_hash()),
+            )
+            submit_feedback_to_mongoDB(
                 question=selected_question,
                 answer=gen_ans,
                 sources=sources,  # Now passing as list


### PR DESCRIPTION
This PR aims to fix a small part of the issue #75 

The objective of this PR can be tracked via the following points 

- [x] Correcting the requirements to now include pyMongo 
- [x] Integrating mongoDB as the database to which the feedback will go back
- [x] referencing different contexts based on their ids to the main table that is the `feedback` table


To view/test these changes, follow the following steps

- run the frontend with the mock server
- specify the `MONGO_DB_URI` to which the feedback and the context would be fed back to
- enter a prompt
- submit a feedback
 - now access the mongoDB instance and you will see the data there, including the timestamp of submissions

This is what I got when I ran this twice

![Screenshot 2024-11-25 at 9 49 49 PM](https://github.com/user-attachments/assets/2a1bf508-1961-48c5-bd0f-6bf93056cb62)
![Screenshot 2024-11-25 at 9 50 04 PM](https://github.com/user-attachments/assets/7d56f5d6-8c64-4bd4-9029-a3a02fc6baaf)


Follow up question, are there limited number of contexts that we have right now for this application, if yes , I might optimise the database insertions to rather not insert the pre-existing contexts, but to reference them and insert their ids into the main table


Thank you !

