### PR TITLE
Persist FAISS index using Docker volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    volumes:
+      - faiss_data:/ORAssistant-backend/faiss_db
     networks:
       - orassistant-network
     healthcheck:
@@ -63,4 +65,6 @@ networks:
 
 volumes:
   postgres_data:
+    driver: local
+  faiss_data:
     driver: local


### PR DESCRIPTION
### Summary
This PR adds a dedicated Docker volume for the FAISS index so that it persists across backend container restarts.

### Changes
Mount a persistent Docker volume to `/ORAssistant-backend/faiss_db` in the backend service

### Context
This change was discussed with @palaniappan-r, who suggested persisting the FAISS index via a separate volume as a useful improvement.

Related issue: #204
