### PR TITLE
feat: add stream field to UserInput for body-controlled SSE streaming

### DIFF
--- a/backend/src/api/models/response_model.py
+++ b/backend/src/api/models/response_model.py
@@ -8,6 +8,7 @@ class UserInput(BaseModel):
     query: str
     list_sources: bool = False
     list_context: bool = False
+    stream: bool = False
     conversation_uuid: Optional[UUID] = None
 
 

--- a/backend/src/api/routers/conversations.py
+++ b/backend/src/api/routers/conversations.py
@@ -245,11 +245,31 @@ def get_optional_db(db: Session = Depends(get_db)) -> Session | None:
     return db if use_db else None
 
 
-@router.post("/agent-retriever", response_model=ChatResponse)
+@router.post("/agent-retriever", response_model=None)
 async def get_agent_response(
     user_input: UserInput, db: Session | None = Depends(get_optional_db)
-) -> ChatResponse:
-    """Processes a user query using the retriever agent, maintains conversation context, and returns the generated response along with relevant context sources and tools used."""
+) -> ChatResponse | StreamingResponse:
+    """Unified chat endpoint.
+
+    Pass ``stream=false`` (default) in the request body to receive a complete
+    JSON response once generation is done.  Pass ``stream=true`` to receive
+    a ``text/event-stream`` response that yields tokens in real time as the
+    LLM produces them.
+
+    Example non-streaming body::
+
+        {"query": "How do I install OpenROAD?", "stream": false}
+
+    Example streaming body::
+
+        {"query": "How do I install OpenROAD?", "stream": true}
+    """
+    if user_input.stream:
+        return StreamingResponse(
+            get_response_stream(user_input, db), media_type="text/event-stream"
+        )
+
+    # --- non-streaming path ---
     user_question = user_input.query
 
     conversation_uuid = user_input.conversation_uuid

--- a/backend/src/api/routers/ui.py
+++ b/backend/src/api/routers/ui.py
@@ -1,17 +1,40 @@
 from fastapi import APIRouter, Request, Response
+from fastapi.responses import StreamingResponse
 import httpx
 import os
 
 router = APIRouter(prefix="/ui", tags=["ui"])
 
 BACKEND_ENDPOINT = os.getenv("BACKEND_ENDPOINT", "http://localhost:8000")
+# Keep a streaming-capable client as well (no timeout for long SSE responses)
 client = httpx.AsyncClient(base_url=BACKEND_ENDPOINT)
+stream_client = httpx.AsyncClient(base_url=BACKEND_ENDPOINT, timeout=None)
 
 
 @router.post("/chat")
-async def proxy_chat(request: Request) -> Response:
+async def proxy_chat(request: Request) -> Response | StreamingResponse:
+    """Proxy to the backend chat endpoint.
+
+    Reads the ``stream`` field from the JSON body.  When ``stream=true`` the
+    response is forwarded as a Server-Sent Events stream so tokens reach the
+    browser in real time.  When ``stream=false`` (default) the full JSON
+    payload is returned once generation completes.
+    """
     data = await request.json()
-    # TODO: set this route dynamically
+    wants_stream: bool = bool(data.get("stream", False))
+
+    if wants_stream:
+        # Open a persistent streaming connection and forward chunks as-is.
+        async def _iter_sse():
+            async with stream_client.stream(
+                "POST", "/conversations/agent-retriever", json=data
+            ) as resp:
+                async for chunk in resp.aiter_text():
+                    yield chunk
+
+        return StreamingResponse(_iter_sse(), media_type="text/event-stream")
+
+    # Non-streaming: wait for the full response, then return it.
     resp = await client.post("/conversations/agent-retriever", json=data)
     return Response(
         content=resp.content,

--- a/backend/tests/test_api_conversations_streaming.py
+++ b/backend/tests/test_api_conversations_streaming.py
@@ -47,6 +47,7 @@ def sample_user_input():
         query="What is OpenROAD?",
         list_sources=False,
         list_context=False,
+        stream=False,
         conversation_uuid=uuid4(),
     )
 
@@ -125,7 +126,7 @@ class TestStreamingEndpoint:
         from src.api.routers.conversations import get_response_stream
 
         user_input = UserInput(
-            query="Test question", list_sources=False, conversation_uuid=None
+            query="Test question", list_sources=False, stream=False, conversation_uuid=None
         )
 
         async def mock_astream_events(*args, **kwargs):
@@ -171,7 +172,7 @@ class TestStreamingEndpoint:
             content="Previous answer",
         )
 
-        user_input = UserInput(query="Follow-up question", conversation_uuid=conv_uuid)
+        user_input = UserInput(query="Follow-up question", stream=False, conversation_uuid=conv_uuid)
 
         captured_inputs = []
 
@@ -386,7 +387,7 @@ class TestStreamingEndpoint:
         from src.api.routers.conversations import get_response_stream
 
         long_query = "A" * 150  # 150 characters
-        user_input = UserInput(query=long_query, conversation_uuid=None)
+        user_input = UserInput(query=long_query, stream=False, conversation_uuid=None)
 
         async def mock_astream_events(*args, **kwargs):
             yield {"event": "on_chat_model_end", "data": {}}
@@ -413,7 +414,7 @@ class TestStreamingEndpoint:
         from src.api.routers.conversations import get_agent_response_streaming
         from starlette.responses import StreamingResponse
 
-        user_input = UserInput(query="Test", conversation_uuid=uuid4())
+        user_input = UserInput(query="Test", stream=False, conversation_uuid=uuid4())
 
         async def mock_astream_events(*args, **kwargs):
             yield {"event": "on_chat_model_end", "data": {}}
@@ -502,3 +503,74 @@ class TestStreamingEndpoint:
         assert any("Sources:" in c for c in chunks)
         sources_chunk = [c for c in chunks if "Sources:" in c][0]
         assert sources_chunk.strip() == "Sources:"
+
+
+class TestUnifiedEndpointStreamBranching:
+    """Verify the unified /agent-retriever endpoint branches on stream field."""
+
+    @pytest.mark.asyncio
+    async def test_get_agent_response_stream_true(
+        self, db_session: Session, mock_retriever_graph
+    ):
+        """When stream=True the unified endpoint must return a StreamingResponse."""
+        from src.api.routers.conversations import get_agent_response
+        from starlette.responses import StreamingResponse
+
+        user_input = UserInput(
+            query="What is OpenROAD?",
+            stream=True,
+            conversation_uuid=uuid4(),
+        )
+
+        async def mock_astream_events(*args, **kwargs):
+            yield {"event": "on_chat_model_end", "data": {}}
+            yield {
+                "event": "on_chat_model_stream",
+                "data": {"chunk": AIMessageChunk(content="streamed token")},
+            }
+
+        mock_retriever_graph.astream_events = mock_astream_events
+
+        response = await get_agent_response(user_input, db_session)
+
+        assert isinstance(response, StreamingResponse), (
+            "Expected StreamingResponse when stream=True, got "
+            f"{type(response).__name__}"
+        )
+        assert response.media_type == "text/event-stream"
+
+    @pytest.mark.asyncio
+    async def test_get_agent_response_stream_false_returns_chat_response(
+        self, db_session: Session
+    ):
+        """When stream=False the unified endpoint must return a plain ChatResponse."""
+        from src.api.routers.conversations import get_agent_response
+        from src.api.models.response_model import ChatResponse
+
+        user_input = UserInput(
+            query="What is OpenROAD?",
+            stream=False,
+            conversation_uuid=uuid4(),
+        )
+
+        # Build a minimal graph output that parse_agent_output can handle
+        fake_output = [
+            {"classify": {"agent_type": ["rag_agent"]}},
+            {"retrieve_general": {"context": "ctx", "sources": [], "urls": [], "context_list": []}},
+            {
+                "rag_generate": {
+                    "messages": ["OpenROAD is a chip design tool."]
+                }
+            },
+        ]
+
+        with patch("src.api.routers.conversations.rg") as mock_rg:
+            mock_rg.graph = MagicMock()
+            mock_rg.graph.stream.return_value = iter(fake_output)
+            response = await get_agent_response(user_input, db_session)
+
+        assert isinstance(response, ChatResponse), (
+            "Expected ChatResponse when stream=False, got "
+            f"{type(response).__name__}"
+        )
+        assert response.response == "OpenROAD is a chip design tool."


### PR DESCRIPTION
## Summary of Changes

| File                                   | Change |
|----------------------------------------|--------|
| `response_model.py`                   | Added `stream: bool = False` to `UserInput`. |
| `conversations.py`                    | Introduced a unified `POST /conversations/agent-retriever` endpoint. Returns `StreamingResponse` when `stream=true` and `ChatResponse` when `stream=false`. Set `response_model=None` to skip FastAPI schema inference for union responses. Kept `/agent-retriever/stream` as a backward-compatible alias. |
| `ui.py`                               | Updated proxy logic to inspect `stream` in the request body. Uses `httpx` streaming context manager (`timeout=None`) for SSE passthrough when `stream=true`; falls back to standard buffered response otherwise. |
| `test_api_conversations_streaming.py` | Updated all existing `UserInput(...)` calls to explicitly set `stream=False`. Added two tests in `TestUnifiedEndpointStreamBranching`: one verifies `stream=true` returns `StreamingResponse`, the other verifies `stream=false` returns `ChatResponse`. |

---

## Usage

### Non-Streaming (default behavior)

```POST /conversations/agent-retriever
{ "query": "How do I install OpenROAD?", "stream": false }```

###Streaming (SSE)

```POST /conversations/agent-retriever
{ "query": "How do I install OpenROAD?", "stream": true }```
https://github.com/The-OpenROAD-Project/ORAssistant/issues/157