### PR TITLE
docs: add EMBEDDINGS_TYPE valid options to README and .env.example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ git clone https://github.com/The-OpenROAD-Project/ORAssistant.git
 ```
 
 **Step 2**: Copy the `.env.example` file, and update your `.env` file with the appropriate API keys.
+> **Note:** When configuring `EMBEDDINGS_TYPE`, valid options are `HF`, `GOOGLE_GENAI`, or `GOOGLE_VERTEXAI`. If using `HF`, no API key is needed but startup is slower. If using `GOOGLE_GENAI`, ensure `GOOGLE_API_KEY` is set.
 
 Modify the Docker `HEALTHCHECK_` variables based on the hardware requirements.
 If you have a resource-constrained PC, try increasing `HEALTHCHECK_START_PERIOD` to a value large
@@ -99,6 +100,7 @@ uv sync
 ```
 
 **Step 2**: Copy the `.env.example` file, and update your `.env` file with the appropriate API keys.
+> **Note:** When configuring `EMBEDDINGS_TYPE`, valid options are `HF`, `GOOGLE_GENAI`, or `GOOGLE_VERTEXAI`. If using `HF`, no API key is needed but startup is slower. If using `GOOGLE_GENAI`, ensure `GOOGLE_API_KEY` is set.
 
 ```bash
 cd backend

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -22,6 +22,7 @@ GOOGLE_GEMINI=2.0_flash
 
 LLM_TEMP=1
 
+# Choose embeddings type (options: HF, GOOGLE_GENAI, GOOGLE_VERTEXAI)
 EMBEDDINGS_TYPE=GOOGLE_GENAI
 GOOGLE_EMBEDDINGS=gemini-embedding-001
 HF_EMBEDDINGS=thenlper/gte-large


### PR DESCRIPTION
## Problem
The `EMBEDDINGS_TYPE` environment variable in `.env.example` had no 
documentation about its valid options. New contributors hitting an 
invalid value would get a confusing `ValueError` with no guidance 
on what values are accepted.

## Changes
- Added a comment above `EMBEDDINGS_TYPE` in `backend/.env.example` 
  listing valid options: `HF`, `GOOGLE_GENAI`, `GOOGLE_VERTEXAI`
- Added a note in `README.md` (both Docker and local setup sections) 
  explaining valid values and their requirements

## Motivation
Encountered this issue while setting up ORAssistant locally — 
the error message says valid options but the docs don't mention 
them at all. This helps new contributors avoid the same confusion.

Relates to #248