### PR TITLE
Fix 4 runtime bugs: crash, streaming None, discarded replace, memory leak

### DIFF
--- a/backend/src/agents/retriever_rag.py
+++ b/backend/src/agents/retriever_rag.py
@@ -107,7 +107,7 @@ class RAG:
         self.tool_descriptions = ""
         for tool in self.tools:
             text_desc = render_text_description([tool])
-            text_desc.replace("(query: str) -> Tuple[str, list[str], list[str]]", " ")
+            text_desc = text_desc.replace("(query: str) -> Tuple[str, list[str], list[str]]", " ")
             self.tool_descriptions += text_desc + "\n\n"
 
     def rag_agent(self, state: AgentState) -> dict[str, list[Any]]:
@@ -159,12 +159,14 @@ class RAG:
                 )
                 return {"tools": []}
 
+            tool_calls: list[str] = []
             if "tool_names" in str(response):
-                tool_calls = response.get("tool_names", [])  # type: ignore
-                for tool in tool_calls:
-                    if tool not in self.tool_names:
+                raw_tool_calls = response.get("tool_names", [])  # type: ignore
+                for tool in raw_tool_calls:
+                    if tool in self.tool_names:
+                        tool_calls.append(tool)
+                    else:
                         logging.warning(f"Tool {tool} not found in tool list.")
-                        tool_calls.remove(tool)
             else:
                 logging.warning(str(response))
                 logging.warning("Tool selection failed. Returning empty tool list.")

--- a/backend/src/api/routers/conversations.py
+++ b/backend/src/api/routers/conversations.py
@@ -1,5 +1,6 @@
 import os
 import logging
+from collections import OrderedDict
 from dotenv import load_dotenv
 
 from typing import Any
@@ -217,7 +218,9 @@ rg = RetrieverGraph(
 rg.initialize()
 
 
-chat_history: dict[UUID, list[dict[str, str]]] = {}
+MAX_IN_MEMORY_CONVERSATIONS = 1000
+
+chat_history: OrderedDict[UUID, list[dict[str, str]]] = OrderedDict()
 
 
 def get_history_str(db: Session | None, conversation_uuid: UUID | None) -> str:
@@ -274,6 +277,8 @@ async def get_agent_response(
 
             conversation_uuid = uuid4()
         if conversation_uuid not in chat_history:
+            if len(chat_history) >= MAX_IN_MEMORY_CONVERSATIONS:
+                chat_history.popitem(last=False)
             chat_history[conversation_uuid] = []
 
     inputs = {
@@ -369,6 +374,8 @@ async def get_response_stream(user_input: UserInput, db: Session | None) -> Any:
 
             conversation_uuid = uuid4()
         if conversation_uuid not in chat_history:
+            if len(chat_history) >= MAX_IN_MEMORY_CONVERSATIONS:
+                chat_history.popitem(last=False)
             chat_history[conversation_uuid] = []
 
     inputs = {
@@ -405,7 +412,7 @@ async def get_response_stream(user_input: UserInput, db: Session | None) -> Any:
 
                 if msg:
                     chunks.append(str(msg))
-                yield str(msg) + "\n\n"
+                    yield str(msg) + "\n\n"
 
     urls = list(set(urls))
     yield f"Sources: {', '.join(urls)}\n\n"


### PR DESCRIPTION
## Summary

Fixes #243 — four bugs, two of which cause runtime crashes or corrupt client output.

- **Bug 1 (crash):** `UnboundLocalError` in `retriever_rag.py` — `tool_calls` referenced before assignment when LLM response lacks `tool_names`. Also fixes list mutation during iteration (`.remove()` while looping).
- **Bug 2 (user-visible):** Streaming endpoint yields literal `"None\n\n"` to clients when `message_content` is not an `AIMessageChunk`. Moved `yield` inside the `if msg:` guard.
- **Bug 3 (minor):** `str.replace()` result discarded in `rag_initialize()` — tool descriptions sent to LLM were never actually cleaned.
- **Bug 4 (memory leak):** In-memory `chat_history` dict grows unboundedly when DB is disabled. Replaced with `OrderedDict` capped at 1000 entries, evicting oldest on overflow.

## Test plan

- [x] All 18 unit tests pass (`pytest -m unit`)
- [x] All 40 retriever/graph/API tests pass
- [ ] Manual test: trigger non-inbuilt-tool-calling path — should no longer crash
- [ ] Manual test: streaming endpoint — should no longer show "None" in output
- [ ] Manual test: run with `USE_DB=false` for 1000+ conversations — oldest should be evicted

🤖 Generated with [Claude Code](https://claude.com/claude-code)