### PR TITLE
fix(eval): bump Gemini model from gemini-2.5-pro to gemini-3.1-pro-preview

### DIFF
--- a/evaluation/auto_evaluation/eval_main.py
+++ b/evaluation/auto_evaluation/eval_main.py
@@ -11,8 +11,8 @@ import os
 from dotenv import load_dotenv
 from deepeval.test_case import LLMTestCase
 from deepeval import evaluate
-from deepeval.models import GeminiModel
 
+from auto_evaluation.src.models.gemini import GoogleGeminiLangChain
 from auto_evaluation.src.metrics.retrieval import (
     make_contextual_precision_metric,
     make_contextual_recall_metric,
@@ -41,10 +41,7 @@ class EvaluationHarness:
         self.dataset = dataset
         self.reranker_base_url = reranker_base_url
         self.qns = preprocess.read_data(self.dataset)
-        self.eval_model = GeminiModel(
-            model_name="gemini-2.5-pro",
-            api_key=os.getenv("GOOGLE_API_KEY"),
-        )
+        self.eval_model = GoogleGeminiLangChain(model_name="gemini-3.1-pro-preview")
         self.log_dir = "logs"
         os.makedirs(self.log_dir, exist_ok=True)
         self.sanity_check()

--- a/evaluation/auto_evaluation/src/models/gemini.py
+++ b/evaluation/auto_evaluation/src/models/gemini.py
@@ -68,7 +68,7 @@ class GoogleGeminiLangChain(DeepEvalBaseLLM):
 
 
 def main():
-    model = GoogleGeminiLangChain(model_name="gemini-2.5-pro")
+    model = GoogleGeminiLangChain(model_name="gemini-3.1-pro-preview")
     prompt = "Write me a joke"
     print(f"Prompt: {prompt}")
     response = model.generate(prompt, schema=Response)
@@ -76,7 +76,7 @@ def main():
 
 
 async def main_async():
-    model = GoogleGeminiLangChain(model_name="gemini-2.5-pro")
+    model = GoogleGeminiLangChain(model_name="gemini-3.1-pro-preview")
     prompt = "Write me a joke"
     print(f"Prompt: {prompt}")
     response = await model.a_generate(prompt, schema=Response)

--- a/evaluation/script_based_evaluation/models/gemini_model.py
+++ b/evaluation/script_based_evaluation/models/gemini_model.py
@@ -58,7 +58,7 @@ def base_gemini_pro(query: str) -> tuple[str, float]:
         try:
             start_time = time.time()
             response = _client.models.generate_content(
-                model="gemini-2.5-pro",
+                model="gemini-3.1-pro-preview",
                 contents=" " + query,
                 config=types.GenerateContentConfig(
                     safety_settings=_safety_config,


### PR DESCRIPTION
gemini-2.5-pro is only on v1 API; deepeval uses v1beta causing 404. Switch to gemini-3.1-pro-preview and use GoogleGeminiLangChain wrapper.