### PR TITLE
gha: use commit sha instead of version/tag

### DIFF
--- a/.github/workflows/ci-changelog.yaml
+++ b/.github/workflows/ci-changelog.yaml
@@ -10,17 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.12'
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec  # v6.3.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -33,7 +33,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676  # v7.0.11
         with:
           token: ${{ secrets.GH_PAT }}
           commit-message: Update report

--- a/.github/workflows/ci-secret.yaml
+++ b/.github/workflows/ci-secret.yaml
@@ -1,7 +1,7 @@
 name: ORAssistant Secret CI
 run-name: ${{ github.actor }} started CI
 
-on: 
+on:
   push:
     branches:
       - master
@@ -21,13 +21,13 @@ jobs:
     runs-on: self-hosted
     steps:
     - name: Setup python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       with:
         python-version: '3.12'
     - name: Install uv
-      uses: astral-sh/setup-uv@v6   
+      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6.8.0
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
     - name: Setup prereqs
       run: |
         make init-dev
@@ -92,7 +92,7 @@ jobs:
 
     - name: Upload Docker logs as artifacts
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
       with:
         name: docker-logs-${{ github.run_id }}
         path: docker-logs/
@@ -100,7 +100,7 @@ jobs:
 
     - name: Upload evaluation output as artifact
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
       with:
         name: evaluation-output-${{ github.run_id }}
         path: evaluation/auto_evaluation/llm_tests_output.txt
@@ -108,7 +108,7 @@ jobs:
         if-no-files-found: ignore
 
     - name: Create commit comment
-      uses: peter-evans/commit-comment@v3
+      uses: peter-evans/commit-comment@5a6f8285b8f2e8376e41fe1b563db48e6cf78c09  # v3.0.0
       with:
         token: ${{ secrets.GH_PAT }}
         body-path: evaluation/auto_evaluation/llm_tests_output.txt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: ORAssistant CI
 run-name: ${{ github.actor }} started CI
 
-on: 
+on:
   pull_request:
     paths:
       - 'backend/**'
@@ -19,15 +19,15 @@ jobs:
     runs-on: self-hosted
     steps:
     - name: Setup python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       with:
         python-version: '3.12'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6   
+      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6.8.0
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
     - name: Setup prereqs
       run: |

--- a/.github/workflows/repostats.yml
+++ b/.github/workflows/repostats.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: run-ghrs
-        uses: jgehrcke/github-repo-stats@v1.4.2
+        uses: jgehrcke/github-repo-stats@306db38ad131cab2aa5f2cd3062bf6f8aa78c1aa  # v1.4.2
         with:
           databranch: repo-stats
           ghtoken: ${{ secrets.GH_PAT }}

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
     - name: Set up prerequisites
       working-directory: ./backend
       run: |


### PR DESCRIPTION
Using commit sha helps prevent chain attacks that have become common.