### PR TITLE
fix(ci): restore HF dataset download in docker-eval job

### DIFF
--- a/.github/workflows/ci-secret.yaml
+++ b/.github/workflows/ci-secret.yaml
@@ -101,6 +101,8 @@ jobs:
       run: |
         if [ ! -d "data" ] || [ -z "$(ls -A data 2>/dev/null)" ]; then
           uv tool install huggingface-hub
+          huggingface-cli download The-OpenROAD-Project/ORAssistant_RAG_Dataset \
+            --repo-type dataset --local-dir ./data
         else
           echo "Dataset already cached on runner, skipping download"
         fi


### PR DESCRIPTION
## Summary

- The `huggingface-cli download` command was accidentally dropped from the `Download HF dataset` step when #291 parallelised the secret CI
- Without it, a cold runner cache left `./data` empty; the Docker container started with no data, the backend never became ready, and the `Wait for graph readiness` step ran its full **3600 s timeout** on every run
- This restores the download so the cache-miss path actually fetches the dataset

## Test plan

- [ ] Verify secret CI completes in expected time on next push to master
- [ ] Confirm cached runs still skip the download (`Dataset already cached on runner, skipping download`)