### PR TITLE
fix(ci): replace deprecated huggingface-cli with hf

### DIFF
--- a/.github/workflows/ci-secret.yaml
+++ b/.github/workflows/ci-secret.yaml
@@ -101,6 +101,8 @@ jobs:
       run: |
         if [ ! -d "data" ] || [ -z "$(ls -A data 2>/dev/null)" ]; then
           uv tool install huggingface-hub
+          huggingface-cli download The-OpenROAD-Project/ORAssistant_RAG_Dataset \
+            --repo-type dataset --local-dir ./data
         else
           echo "Dataset already cached on runner, skipping download"
         fi

--- a/.github/workflows/ci-secret.yaml
+++ b/.github/workflows/ci-secret.yaml
@@ -101,7 +101,7 @@ jobs:
       run: |
         if [ ! -d "data" ] || [ -z "$(ls -A data 2>/dev/null)" ]; then
           uv tool install huggingface-hub
-          huggingface-cli download The-OpenROAD-Project/ORAssistant_RAG_Dataset \
+          hf download The-OpenROAD-Project/ORAssistant_RAG_Dataset \
             --repo-type dataset --local-dir ./data
         else
           echo "Dataset already cached on runner, skipping download"


### PR DESCRIPTION
## Summary

- `huggingface-cli` is deprecated in newer versions of `huggingface-hub` and exits with code 1, breaking the `docker-eval` CI job
- Replace `huggingface-cli download` with the new `hf download` CLI that ships with the same package

Fixes workflow run [27056972488](https://github.com/The-OpenROAD-Project/ORAssistant/actions/runs/27056972488).

## Test plan

- [x] Verify `docker-eval / Download HF dataset` step passes in CI