### PR TITLE
fix(backend): resolve five backend bugs reported in #259

### DIFF
--- a/backend/src/agents/retriever_typing.py
+++ b/backend/src/agents/retriever_typing.py
@@ -6,6 +6,7 @@ from langgraph.graph.message import add_messages
 class AgentState(TypedDict):
     messages: Annotated[list[AnyMessage], add_messages]
     context: Annotated[list[AnyMessage], add_messages]
+    context_list: Annotated[list[str], add_messages]
     tools: list[str]
     sources: Annotated[list[str], add_messages]
     urls: Annotated[list[str], add_messages]

--- a/backend/src/api/routers/helpers.py
+++ b/backend/src/api/routers/helpers.py
@@ -11,7 +11,22 @@ GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
 if not GOOGLE_API_KEY:
     raise RuntimeError("GOOGLE_API_KEY is not set")
 
-model = "gemini-2.0-flash"
+_GEMINI_MODEL_MAP = {
+    "2.0_flash": "gemini-2.0-flash",
+    "2.5_flash": "gemini-2.5-flash",
+    "2.5_pro": "gemini-2.5-pro",
+}
+
+
+def _resolve_gemini_model(gemini_version: str | None) -> str:
+    """Map a GOOGLE_GEMINI version string to a Gemini model name.
+
+    Falls back to ``gemini-2.0-flash`` when the value is unset or unknown.
+    """
+    return _GEMINI_MODEL_MAP.get(gemini_version or "", "gemini-2.0-flash")
+
+
+model = _resolve_gemini_model(os.getenv("GOOGLE_GEMINI"))
 client = OpenAI(
     base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
     api_key=GOOGLE_API_KEY,

--- a/backend/src/prompts/prompt_templates.py
+++ b/backend/src/prompts/prompt_templates.py
@@ -11,7 +11,7 @@ The user does not have access to the context.
 You must not ask the user to refer to the context in any part of your answer.
 You must not ask the user to refer to a link that is not a part of your answer.
 
-If there is nothing in the context relevant to the question, simply say "Sorry its not avaiable in my knowledge base."
+If there is nothing in the context relevant to the question, simply say "Sorry, it's not available in my knowledge base."
 Do not try to make up an answer.
 Anything between the following `context`  html blocks is retrieved from a knowledge bank, not part of the conversation with the user.
 

--- a/backend/src/tools/process_pdf.py
+++ b/backend/src/tools/process_pdf.py
@@ -31,6 +31,7 @@ def process_pdf_docs(file_path: str) -> list[Document]:
         documents = loader.load_and_split(text_splitter=text_splitter)
     except PdfStreamError:
         logging.error(f"Error processing PDF: {file_path} is corrupted or incomplete.")
+        return []
 
     for doc in documents:
         try:

--- a/backend/src/vectorstores/faiss.py
+++ b/backend/src/vectorstores/faiss.py
@@ -214,6 +214,9 @@ class FAISSVectorDatabase:
         return None
 
     def get_db_path(self) -> str:
+        env_path = os.getenv("FAISS_DB_PATH")
+        if env_path:
+            return os.path.abspath(env_path)
         cur_path = os.path.abspath(__file__)
         path = os.path.join(cur_path, "../../../", "faiss_db")
         path = os.path.abspath(path)  # Ensure proper parent directory

--- a/backend/tests/test_api_helpers.py
+++ b/backend/tests/test_api_helpers.py
@@ -81,6 +81,22 @@ class TestApiHelpers:
         assert model == "gemini-2.0-flash"
         # GOOGLE_API_KEY should be set or raise error during module import
 
+    def test_resolve_gemini_model_maps_known_versions(self):
+        """_resolve_gemini_model maps GOOGLE_GEMINI values to model names (issue #259)."""
+        from src.api.routers.helpers import _resolve_gemini_model
+
+        assert _resolve_gemini_model("2.0_flash") == "gemini-2.0-flash"
+        assert _resolve_gemini_model("2.5_flash") == "gemini-2.5-flash"
+        assert _resolve_gemini_model("2.5_pro") == "gemini-2.5-pro"
+
+    def test_resolve_gemini_model_defaults_for_unknown_or_unset(self):
+        """_resolve_gemini_model falls back to gemini-2.0-flash for unset/unknown values."""
+        from src.api.routers.helpers import _resolve_gemini_model
+
+        assert _resolve_gemini_model(None) == "gemini-2.0-flash"
+        assert _resolve_gemini_model("") == "gemini-2.0-flash"
+        assert _resolve_gemini_model("nonexistent") == "gemini-2.0-flash"
+
     def test_router_configuration(self):
         """Test that router is properly configured."""
         from src.api.routers.helpers import router

--- a/backend/tests/test_faiss_vectorstore.py
+++ b/backend/tests/test_faiss_vectorstore.py
@@ -184,7 +184,7 @@ class TestFAISSVectorDatabase:
                 db.add_md_docs(folder_paths="not_a_list")
 
     def test_get_db_path(self):
-        """Test get_db_path returns correct path."""
+        """get_db_path falls back to the default ./faiss_db when FAISS_DB_PATH is unset."""
         with patch("src.vectorstores.faiss.HuggingFaceEmbeddings") as mock_hf:
             mock_hf.return_value = Mock()
 
@@ -192,9 +192,26 @@ class TestFAISSVectorDatabase:
                 embeddings_type="HF", embeddings_model_name="test-model"
             )
 
-            path = db.get_db_path()
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("FAISS_DB_PATH", None)
+                path = db.get_db_path()
+
             assert path.endswith("faiss_db")
             assert os.path.isabs(path)
+
+    def test_get_db_path_respects_env_var(self):
+        """get_db_path honors the FAISS_DB_PATH environment variable (issue #259)."""
+        with patch("src.vectorstores.faiss.HuggingFaceEmbeddings") as mock_hf:
+            mock_hf.return_value = Mock()
+
+            db = FAISSVectorDatabase(
+                embeddings_type="HF", embeddings_model_name="test-model"
+            )
+
+            with patch.dict(os.environ, {"FAISS_DB_PATH": "custom_dir/faiss_index"}):
+                path = db.get_db_path()
+
+            assert path == os.path.abspath("custom_dir/faiss_index")
 
     def test_save_db_without_documents_raises_error(self):
         """Test save_db raises error when no documents in database."""

--- a/backend/tests/test_process_pdf.py
+++ b/backend/tests/test_process_pdf.py
@@ -77,15 +77,27 @@ class TestProcessPDF:
         assert all(doc.metadata["url"] == "https://example1.com" for doc in result)
         assert all(doc.metadata["source"] == "doc1.pdf" for doc in result)
 
-    # Note: Commented out due to bug in process_pdf_docs function
-    # The function doesn't properly handle PdfStreamError - it logs but then
-    # tries to use undefined 'documents' variable
-    # @patch('src.tools.process_pdf.logging')
-    # @patch('src.tools.process_pdf.PyPDFLoader')
-    # @patch('builtins.open', new_callable=mock_open, read_data='{"corrupted.pdf": "https://example.com"}')
-    # def test_process_pdf_docs_corrupted_file(self, mock_file, mock_loader, mock_logging):
-    #     """Test PDF processing with corrupted file."""
-    #     pass
+    @patch("src.tools.process_pdf.PyPDFLoader")
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data='{"corrupted.pdf": "https://example.com"}',
+    )
+    def test_process_pdf_docs_corrupted_file_returns_empty(
+        self, mock_file, mock_loader
+    ):
+        """A corrupted PDF (PdfStreamError) should return [] instead of crashing."""
+        from pypdf.errors import PdfStreamError
+
+        mock_loader_instance = Mock()
+        mock_loader_instance.load_and_split.side_effect = PdfStreamError(
+            "corrupted stream"
+        )
+        mock_loader.return_value = mock_loader_instance
+
+        result = process_pdf_docs("./corrupted.pdf")
+
+        assert result == []
 
     @patch("src.tools.process_pdf.logging")
     @patch("src.tools.process_pdf.PyPDFLoader")

--- a/backend/tests/test_prompt_templates.py
+++ b/backend/tests/test_prompt_templates.py
@@ -48,3 +48,13 @@ class TestPromptTemplates:
         assert isinstance(suggested_questions_prompt_template, str)
         assert suggested_questions_prompt_template != ""
         assert suggested_questions_prompt_template is not None
+
+    def test_summarise_prompt_template_has_no_typo(self):
+        """summarise_prompt_template should use correct spelling (issue #259)."""
+        from src.prompts.prompt_templates import summarise_prompt_template
+
+        assert "avaiable" not in summarise_prompt_template
+        assert (
+            "Sorry, it's not available in my knowledge base."
+            in summarise_prompt_template
+        )

--- a/backend/tests/test_retriever_typing.py
+++ b/backend/tests/test_retriever_typing.py
@@ -1,0 +1,14 @@
+from src.agents.retriever_typing import AgentState
+
+
+class TestAgentState:
+    """Test suite for the AgentState TypedDict."""
+
+    def test_agent_state_includes_context_list(self):
+        """AgentState must declare context_list so LangGraph propagates it (issue #259).
+
+        ToolNode.get_node returns a ``context_list`` key, but LangGraph drops any
+        state key that is not declared on the graph's state schema. Without this
+        annotation the retrieved context list is silently lost downstream.
+        """
+        assert "context_list" in AgentState.__annotations__


### PR DESCRIPTION
## Summary

Fixes all five bugs reported in #259 (thanks @sanjibani for the detailed review). Each fix is small, isolated, and covered by a regression test written test-first.

| # | File | Bug | Fix |
|---|------|-----|-----|
| 1 | `tools/process_pdf.py` | `UnboundLocalError` after a corrupted PDF raises `PdfStreamError` — the `except` logged but never returned, then the loop iterated the unassigned `documents` | `return []` in the `except` block |
| 2 | `vectorstores/faiss.py` | `get_db_path()` ignored `FAISS_DB_PATH` and always used the hardcoded `../../../faiss_db` | read `FAISS_DB_PATH` first, fall back to the computed default |
| 3 | `agents/retriever_typing.py` | `AgentState` had no `context_list`, so the value returned by `ToolNode.get_node()` was silently dropped by LangGraph | add `context_list: Annotated[list[str], add_messages]` |
| 4 | `api/routers/helpers.py` | model hardcoded to `gemini-2.0-flash`, ignoring `GOOGLE_GEMINI` (which `conversations.py` honors) | resolve via a small `GOOGLE_GEMINI` → model map (default `gemini-2.0-flash`) |
| 5 | `prompts/prompt_templates.py` | typo `"Sorry its not avaiable..."` | `"Sorry, it's not available in my knowledge base."` |

## Tests

7 new/updated unit tests (red → green):

- `test_process_pdf_docs_corrupted_file_returns_empty`
- `test_get_db_path_respects_env_var`, plus hardened the existing `test_get_db_path` to be deterministic w.r.t. `FAISS_DB_PATH`
- `test_agent_state_includes_context_list` (new `tests/test_retriever_typing.py`)
- `test_resolve_gemini_model_maps_known_versions`, `test_resolve_gemini_model_defaults_for_unknown_or_unset`
- `test_summarise_prompt_template_has_no_typo`

`make check` clean: `mypy .` (strict) → no issues in 63 source files; `ruff check` → all checks passed; `ruff format` clean. Full backend suite passes.

Closes #259
