### PR TITLE
fix(agents): add default None values to RetrieverTools class attributes

### DIFF
--- a/backend/src/agents/retriever_tools.py
+++ b/backend/src/agents/retriever_tools.py
@@ -21,22 +21,22 @@ class RetrieverTools:
 
     install_retriever: Optional[
         Union[EnsembleRetriever, ContextualCompressionRetriever]
-    ]
+    ] = None
     general_retriever: Optional[
         Union[EnsembleRetriever, ContextualCompressionRetriever]
-    ]
+    ] = None
     commands_retriever: Optional[
         Union[EnsembleRetriever, ContextualCompressionRetriever]
-    ]
+    ] = None
     errinfo_retriever: Optional[
         Union[EnsembleRetriever, ContextualCompressionRetriever]
-    ]
+    ] = None
     yosys_rtdocs_retriever: Optional[
         Union[EnsembleRetriever, ContextualCompressionRetriever]
-    ]
+    ] = None
     klayout_retriever: Optional[
         Union[EnsembleRetriever, ContextualCompressionRetriever]
-    ]
+    ] = None
     tool_descriptions: str = ""
 
     def initialize(


### PR DESCRIPTION
## Summary
- Bare type annotations without default values (e.g. `install_retriever: Optional[...]`) do not create class attributes in Python — they only populate `__annotations__`
- This caused `hasattr(RetrieverTools, "install_retriever")` to return `False`, breaking `TestRetrieverTools.test_class_attributes_structure` in CI
- Added `= None` defaults to all six retriever class attributes to match the existing `None`-check guards already present in the code

## Test plan
- [x] `pytest tests/test_retriever_tools.py::TestRetrieverTools::test_class_attributes_structure` passes
- [x] Full unit test suite passes