### PR TITLE
chore(deps): add dependabot config for scheduled version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,57 @@
+version: 2
+updates:
+  - package-ecosystem: uv
+    directories:
+      - /backend
+      - /evaluation
+      - /frontend
+      - /frontend/mock-flask-api
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    groups:
+      python:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /frontend/nextjs-frontend
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    groups:
+      npm:
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directories:
+      - /backend
+      - /common
+      - /frontend
+      - /frontend/nextjs-frontend
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    groups:
+      images:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Dependabot has only ever run here via automatic security updates (no config file, hence the auto-named "uv group"/"npm_and_yarn" PRs in history). Add scheduled weekly updates for uv (backend, evaluation, frontend, frontend/mock-flask-api), npm (frontend/nextjs-frontend), docker (backend, common, frontend, frontend/nextjs-frontend), and github-actions, each grouped into one PR per ecosystem per week.